### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/TapJoyAdapterAd.swift
+++ b/Source/TapJoyAdapterAd.swift
@@ -105,7 +105,7 @@ extension TapJoyAdapterAd: TJPlacementDelegate {
     }
     
     func requestDidFail(_ placement: TJPlacement, error partnerError: Error?) {
-        let error = error(.loadFailureUnknown, error: partnerError)
+        let error = partnerError ?? error(.loadFailureUnknown)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
