### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/TapJoyAdapter.swift
+++ b/Source/TapJoyAdapter.swift
@@ -8,10 +8,10 @@
 //  ChartboostHeliumAdapterTapJoy
 //
 
+import ChartboostMediationSDK
 import Foundation
-import UIKit
-import HeliumSdk
 import Tapjoy
+import UIKit
 
 /// Helium TapJoy adapter.
 final class TapJoyAdapter: PartnerAdapter {

--- a/Source/TapJoyAdapterAd.swift
+++ b/Source/TapJoyAdapterAd.swift
@@ -8,10 +8,10 @@
 //  ChartboostHeliumAdapterTapJoy
 //
 
+import ChartboostMediationSDK
 import Foundation
-import UIKit
-import HeliumSdk
 import Tapjoy
+import UIKit
 
 /// The Helium Tapjoy adapter ad.
 final class TapJoyAdapterAd: NSObject, PartnerAd {


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.