### PR TITLE
HB-6741: Add base privacy manifest

### DIFF
--- a/ChartboostMediationAdapterTapjoy.podspec
+++ b/ChartboostMediationAdapterTapjoy.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
   # Source
   spec.module_name  = 'ChartboostMediationAdapterTapjoy'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-tapjoy.git', :tag => spec.version }
+  spec.resource_bundles = { 'ChartboostMediationAdapterTapjoy' => ['PrivacyInfo.xcprivacy'] }
   spec.source_files = 'Source/**/*.{swift}'
   spec.static_framework = true
 

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-6741

For the TapJoy adapter, the privacy manifest can be bare-bones.